### PR TITLE
Fix 'Use Email to Validate Domain Ownership' link.

### DIFF
--- a/doc_source/acm-bestpractices.md
+++ b/doc_source/acm-bestpractices.md
@@ -29,7 +29,7 @@ If you decide to pin a certificate, the following options will not hinder your a
 
 ## Domain Validation<a name="best-practices-validating"></a>
 
-Before the Amazon certificate authority \(CA\) can issue a certificate for your site, AWS Certificate Manager \(ACM\) must verify that you own or control all the domains that you specified in your request\. You can perform verification using either email or DNS\. For more information, see [Use Email to Validate Domain Ownership](gs-acm-validate-dns.md) and [Use DNS to Validate Domain Ownership](gs-acm-validate-dns.md)\. 
+Before the Amazon certificate authority \(CA\) can issue a certificate for your site, AWS Certificate Manager \(ACM\) must verify that you own or control all the domains that you specified in your request\. You can perform verification using either email or DNS\. For more information, see [Use Email to Validate Domain Ownership](gs-acm-validate-email.md) and [Use DNS to Validate Domain Ownership](gs-acm-validate-dns.md)\. 
 
 ## Adding or Deleting Domain Names<a name="best-practices-add-delete"></a>
 


### PR DESCRIPTION
*Issue:* The "Use Email to Validate Domain Ownership" link was wrong and pointed to the "Use DNS to Validate Domain Ownership" page.

*Description of changes:* Fix the "Use Email to Validate Domain Ownership" link to point to the correct page. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 