### PR TITLE
Updated Import a Certificate Example to use fileb

### DIFF
--- a/doc_source/import-certificate-api-cli.md
+++ b/doc_source/import-certificate-api-cli.md
@@ -38,9 +38,9 @@ The following example shows how to import a certificate using the [AWS Command L
 To use the following example, replace the file names with your own and type the command on one continuous line\. The following example includes line breaks and extra spaces to make it easier to read\.
 
 ```
-  	$ aws acm import-certificate --certificate file://Certificate.pem
-                                 --certificate-chain file://CertificateChain.pem
-                                 --private-key file://PrivateKey.pem
+  	$ aws acm import-certificate --certificate fileb://Certificate.pem
+                                 --certificate-chain fileb://CertificateChain.pem
+                                 --private-key fileb://PrivateKey.pem
 ```
 
 If the `import-certificate` command is successful, it returns the [Amazon Resource Name \(ARN\)](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) of the imported certificate\. 


### PR DESCRIPTION
Reference: https://github.com/aws/aws-cli/issues/4978#issuecomment-592229037

*Description of changes:*
When using `aws-cli/2.0.2` the example fails when using file with PEM-encoded content. By updating to `fileb://` it works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
