### PR TITLE
Typo in export-private

### DIFF
--- a/doc_source/export-private.md
+++ b/doc_source/export-private.md
@@ -3,7 +3,7 @@
 You can export a certificate issued by ACM Private CA for use anywhere in your private PKI environment\. The exported file contains the certificate, the certificate chain, and the encrypted private key\. This file must be stored securely\. For more information about ACM Private CA, see [AWS Certificate Manager Private Certificate Authority User Guide](https://docs.aws.amazon.com/acm-pca/latest/userguide/)\.
 
 **Note**  
-You cannot export a publicly trusted ACM certificate or it private key\.
+You cannot export a publicly trusted ACM certificate or its private key\.
 
 **Topics**
 + [Exporting a private certificate \(console\)](#export-console)


### PR DESCRIPTION
Only changed "it private key" to "its private key", I presume this was the intent behind that phrasing.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*